### PR TITLE
anchor-scroll-hash -> anchor-hash-scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# anchor-scroll-hash
+# anchor-hash-scroll
 
 ### [Demo](http://jayrbolton.github.io/anchor-hash-scroll)
 
@@ -12,7 +12,7 @@ See **jump.js** smooth scrolling options [here](https://github.com/callmecavs/ju
 
 ### Example:
 ```js
-const anchorScroll = require('anchor-scroll-hash')
+const anchorScroll = require('anchor-hash-scroll')
 // takes options for smooth scrolling (jump.js)
 anchorScroll({
   duration: 3000


### PR DESCRIPTION
The name of the package was not always consistent so I fixed it in the README.

Thanks for the module :-)